### PR TITLE
安卓修改中文替换文件目录为strings-zh-rCN，避免因版本更新出现新词 导致软件无法启动

### DIFF
--- a/android/apktools.py
+++ b/android/apktools.py
@@ -407,7 +407,7 @@ def replace_language_xml(source_dir, target_dir):
     if not os.path.exists(source_dir):
         raise Exception(f"Failed to replace {LANGUAGE_XML}, source file not found: {source_dir}")
     src_xml = os.path.join(source_dir, LANGUAGE_XML)
-    tar_xml = os.path.join(target_dir, 'resources', 'package_1', 'res', 'values', LANGUAGE_XML)
+    tar_xml = os.path.join(target_dir, 'resources', 'package_1', 'res', 'values-zh-rCN', LANGUAGE_XML)
     logger.info(f"Replacing language file: Source={src_xml}, Target={tar_xml}")
     replace_file(src_xml, tar_xml)
 

--- a/android/strings.xml
+++ b/android/strings.xml
@@ -2234,9 +2234,11 @@ echo '$3' &gt;&gt; "$1/$2";</string>
   <string name="settings_login_title">登录</string>
   <string name="settings_logout_title">退出登录</string>
   <string name="settings_never">永不</string>
+  <string name="settings_normal_input_type_in_terminal_summary">支持语音输入及中日韩语言（CJK）</string>
+  <string name="settings_normal_input_type_in_terminal_title">键盘支持（实验功能）</string>
   <string name="settings_notification_category_title">通知</string>
   <string name="settings_notification_icon_summary">自定义或禁用活动连接显示</string>
-  <string name="settings_notification_icon_summary_allow">后台显示活动连接所需</string>
+  <string name="settings_notification_icon_summary_allow">后台显示活动连接所需的权限</string>
   <string name="settings_notification_icon_title">更改通知设置</string>
   <string name="settings_notification_icon_title_allow">启用通知</string>
   <string name="settings_null_apikey_title">账户设置</string>


### PR DESCRIPTION
安卓版本更新新增两个新词
Experimental Keyboard Support
Voice input and CJK layout support
已添加翻译，并修改 .py 文件，替换strings.xml到 zh-rCN目录下。有效避免因版本更新出现新词 导致软件无法启动的问题